### PR TITLE
Fix BDA data encryption

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -263,9 +263,8 @@ function getBda(userAgent) {
         },
     ];
     let time = new Date().getTime() / 1000;
-    let key = userAgent + Math.round(time - (time % 21600));
     let s = JSON.stringify(bda);
-    let encrypted = crypt_1.default.encrypt(s, key);
+    let encrypted = crypt_1.default.encrypt(s, userAgent);
     return Buffer.from(encrypted).toString("base64");
 }
 exports.default = {

--- a/src/util.ts
+++ b/src/util.ts
@@ -271,11 +271,9 @@ function getBda(userAgent: string): string {
         },
     ];
 
-    let time = new Date().getTime() / 1000;
-    let key = userAgent + Math.round(time - (time % 21600));
-    
+    let time = new Date().getTime() / 1000;    
     let s = JSON.stringify(bda);
-    let encrypted = crypt.encrypt(s, key);
+    let encrypted = crypt.encrypt(s, userAgent); // pass useragent instead
     return Buffer.from(encrypted).toString("base64");
 }
 


### PR DESCRIPTION
ROBLOX decrypts BDA data using your user-agent so passing a random user-agent will make the BDA data pointless and thus give you an unsolvable captcha.